### PR TITLE
fix: Save metrics node not working

### DIFF
--- a/app/back/basic_auth.go
+++ b/app/back/basic_auth.go
@@ -22,5 +22,3 @@ func (b basicAuth) GetRequestMetadata(ctx context.Context, in ...string) (map[st
 func (basicAuth) RequireTransportSecurity() bool {
 	return true
 }
-
-var bauth basicAuth = basicAuth{username: os.Getenv("USERNAME"), password: os.Getenv("PASSWORD")}

--- a/app/back/basic_auth.go
+++ b/app/back/basic_auth.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+)
+
+type basicAuth struct {
+	username string
+	password string
+}
+
+func (b basicAuth) GetRequestMetadata(ctx context.Context, in ...string) (map[string]string, error) {
+	auth := b.username + ":" + b.password
+	enc := base64.StdEncoding.EncodeToString([]byte(auth))
+	return map[string]string{
+		"authorization": "Basic " + enc,
+	}, nil
+}
+
+func (basicAuth) RequireTransportSecurity() bool {
+	return true
+}
+
+var bauth basicAuth = basicAuth{username: os.Getenv("USERNAME"), password: os.Getenv("PASSWORD")}

--- a/app/back/basic_auth.go
+++ b/app/back/basic_auth.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/base64"
-	"os"
 )
 
 type basicAuth struct {

--- a/app/back/main.go
+++ b/app/back/main.go
@@ -9,9 +9,9 @@ import (
 )
 
 const defaultPort = "4000"
-const bauth basicAuth = basicAuth{username: os.Getenv("USERNAME"), password: os.Getenv("PASSWORD")}
 
 var tlsConf tls.Config
+var bauth basicAuth = basicAuth{username: os.Getenv("USERNAME"), password: os.Getenv("PASSWORD")}
 
 var config struct {
 	Port       string

--- a/app/back/main.go
+++ b/app/back/main.go
@@ -9,6 +9,7 @@ import (
 )
 
 const defaultPort = "4000"
+const bauth basicAuth = basicAuth{username: os.Getenv("USERNAME"), password: os.Getenv("PASSWORD")}
 
 var tlsConf tls.Config
 

--- a/app/back/make_prediction.go
+++ b/app/back/make_prediction.go
@@ -2,39 +2,18 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 
 	"github.com/golang/protobuf/jsonpb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
 
-type basicAuth struct {
-	username string
-	password string
-}
-
-func (b basicAuth) GetRequestMetadata(ctx context.Context, in ...string) (map[string]string, error) {
-	auth := b.username + ":" + b.password
-	enc := base64.StdEncoding.EncodeToString([]byte(auth))
-	return map[string]string{
-		"authorization": "Basic " + enc,
-	}, nil
-}
-
-func (basicAuth) RequireTransportSecurity() bool {
-	return true
-}
-
 func proxyMakePrediction(w http.ResponseWriter, req *http.Request) {
-
-	bauth := basicAuth{username: os.Getenv("USERNAME"), password: os.Getenv("PASSWORD")}
 
 	setupResponse(&w, req)
 	if (*req).Method == "OPTIONS" {

--- a/app/back/save_metrics.go
+++ b/app/back/save_metrics.go
@@ -38,7 +38,8 @@ func proxySaveMetrics(w http.ResponseWriter, req *http.Request) {
 
 		log.Println("--------------  Calling SavePredictionMetric Service -------------")
 
-		cc, err := grpc.Dial(config.Entrypoint, grpc.WithTransportCredentials(credentials.NewTLS(&tlsConf)))
+		cc, err := grpc.Dial(config.Entrypoint, grpc.WithTransportCredentials(credentials.NewTLS(&tlsConf)),
+			grpc.WithPerRPCCredentials(bauth))
 		if err != nil {
 			err := fmt.Errorf("error calling service: %w", err)
 			sendErrorResponse(w, err, http.StatusInternalServerError)

--- a/runtime/src/save-prediction-metric/main.py
+++ b/runtime/src/save-prediction-metric/main.py
@@ -9,7 +9,7 @@ async def handler(ctx, data):
 
     ctx.logger.info(f"Adding real value to prediction: {req.real_category}")
     date = datetime.fromtimestamp(req.date)
-    await ctx.prediction.save(req.predicted_category, req.real_category, date)
+    await ctx.prediction.save(req.predicted_category, req.real_category, date.isoformat())
 
     res = SaveMetricResponse()
     res.success = True


### PR DESCRIPTION
This PR adds:

- save-prediction-metric not working because a `datetime` (not JSON serializable) object was being passed
- `bauth` refactor